### PR TITLE
feat: single-process SSE + LaunchAgent for Tailscale

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,6 +127,19 @@ Then point your remote client at:
 
 Override host/port with `FASTMCP_HOST` and `FASTMCP_PORT` if needed. Binding to `0.0.0.0` exposes the service on all interfaces; use `127.0.0.1` for local-only access.
 
+#### Tailscale / always-on Mac (single process, recommended)
+
+For **private** remote access (e.g. Tailscale) without `mcp-proxy` + `mcp_gateway`, use one LaunchAgent-supervised process:
+
+```bash
+./scripts/run_http_service.sh
+```
+
+That writes `.runtime/deployed.json`, loads an optional bearer from Keychain (`mac-messages-mcp/api-key`), and runs **one** Uvicorn stack (see `mac_messages_mcp/http_server.py`). Rationale: [issue #3](https://github.com/jonchui/mac_messages_mcp/issues/3).
+
+- **Auth (optional):** set `MAC_MESSAGES_MCP_BEARER_TOKEN`, or use the same Keychain entry as the legacy proxy. Remote clients: `Authorization: Bearer …` or `X-API-Key`.
+- **Legacy WAN stack:** `scripts/start_mcp_proxy.sh` + `scripts/mcp_gateway.py` remain for tunnel / multi-process setups.
+
 ### Docker Container Integration
 
 If you need to connect to `mac-messages-mcp` from a Docker container, you can either run the server with `MCP_TRANSPORT=sse` as above and use `http://host.docker.internal:8000`, or use the `mcp-proxy` package to bridge the stdio-based server to HTTP.

--- a/README.md
+++ b/README.md
@@ -135,7 +135,7 @@ For **private** remote access (e.g. Tailscale) without `mcp-proxy` + `mcp_gatewa
 ./scripts/run_http_service.sh
 ```
 
-That writes `.runtime/deployed.json`, loads an optional bearer from Keychain (`mac-messages-mcp/api-key`), and runs **one** Uvicorn stack (see `mac_messages_mcp/http_server.py`). Rationale: [issue #3](https://github.com/jonchui/mac_messages_mcp/issues/3).
+That writes `.runtime/deployed.json`, loads an optional bearer from Keychain (`mac-messages-mcp/api-key`), and runs **one** Uvicorn stack (see `mac_messages_mcp/http_server.py`). Rationale: [issue #3](https://github.com/jonchui/mac_messages_mcp/issues/3). **Deploy / audit:** [`docs/DEPLOY_MAC_MINI.md`](docs/DEPLOY_MAC_MINI.md) and `scripts/deploy_mac_mini.sh`.
 
 - **Auth (optional):** set `MAC_MESSAGES_MCP_BEARER_TOKEN`, or use the same Keychain entry as the legacy proxy. Remote clients: `Authorization: Bearer …` or `X-API-Key`.
 - **Legacy WAN stack:** `scripts/start_mcp_proxy.sh` + `scripts/mcp_gateway.py` remain for tunnel / multi-process setups.

--- a/deploy/launchagents/com.jonchui.mac-messages-mcp.plist.template
+++ b/deploy/launchagents/com.jonchui.mac-messages-mcp.plist.template
@@ -7,7 +7,8 @@
 
   <key>ProgramArguments</key>
   <array>
-    <string>/Users/jonchui/Applications/MacMessagesMCP.app/Contents/MacOS/macmessagesmcp-launcher</string>
+    <string>/bin/bash</string>
+    <string>/Users/jonchui/Library/Mobile Documents/com~apple~CloudDocs/code/mac_messages_mcp/scripts/run_http_service.sh</string>
   </array>
 
   <key>RunAtLoad</key>
@@ -27,15 +28,13 @@
 
   <key>EnvironmentVariables</key>
   <dict>
-    <key>MCP_PROXY_HOST</key>
+    <key>MCP_TRANSPORT</key>
+    <string>sse</string>
+    <key>FASTMCP_HOST</key>
     <string>0.0.0.0</string>
-    <key>MCP_PROXY_PORT</key>
+    <key>FASTMCP_PORT</key>
     <string>8000</string>
-    <key>MCP_PROXY_SERVER_MODE</key>
-    <string>both</string>
-    <key>MCP_PROXY_TUNNEL</key>
-    <string>1</string>
-    <key>MCP_PROXY_API_KEY</key>
+    <key>MAC_MESSAGES_MCP_BEARER_TOKEN</key>
     <string></string>
   </dict>
 </dict>

--- a/docs/DEPLOY_MAC_MINI.md
+++ b/docs/DEPLOY_MAC_MINI.md
@@ -5,7 +5,21 @@ This repo’s **LaunchAgent** should run **`scripts/run_http_service.sh`** (sing
 ## Prerequisites
 
 - **SSH** to the mini as a user that owns the git clone and LaunchAgent (usually your macOS account).
-- **Clone path** must match **`ProgramArguments`** in `~/Library/LaunchAgents/com.jonchui.mac-messages-mcp.plist` (often iCloud Drive path from the plist template).
+- **Clone path** must match **`ProgramArguments`** and **`WorkingDirectory`** in `~/Library/LaunchAgents/com.jonchui.mac-messages-mcp.plist`.
+
+### iCloud Drive and LaunchAgent (critical)
+
+macOS often returns **`Operation not permitted` (exit 126)** when **LaunchAgent** runs **`/bin/bash …/run_http_service.sh`** from **`Library/Mobile Documents/`** (iCloud-synced “Desktop & Documents”). Login **SSH** works; **launchd** does not.
+
+**Fix:** keep an **extra clone outside iCloud** for the daemon only, e.g. **`$HOME/src/mac_messages_mcp`**, and point the plist **`ProgramArguments`** + **`WorkingDirectory`** at that path (`PlistBuddy` or edit by hand). Use **git** to sync; keep iCloud copy for editor convenience if you want.
+
+```bash
+mkdir -p ~/src
+git clone https://github.com/jonchui/mac_messages_mcp.git ~/src/mac_messages_mcp
+cd ~/src/mac_messages_mcp && git checkout feat/tailscale-single-process-sse   # or main
+# Then set LaunchAgent script + WorkingDirectory to this path and reload the plist.
+```
+
 - **Tailscale** on laptop + mini (or LAN) so you can use `100.x.x.x` or MagicDNS.
 
 This Cursor/agent environment **does not** have your SSH keys or Tailscale DNS; **you** run the commands below from a trusted machine.

--- a/docs/DEPLOY_MAC_MINI.md
+++ b/docs/DEPLOY_MAC_MINI.md
@@ -1,0 +1,48 @@
+# Deploy: Mac mini (Tailscale / always-on MCP)
+
+This repo’s **LaunchAgent** should run **`scripts/run_http_service.sh`** (single-process SSE). See [issue #3](https://github.com/jonchui/mac_messages_mcp/issues/3) and [PR #4](https://github.com/jonchui/mac_messages_mcp/pull/4).
+
+## Prerequisites
+
+- **SSH** to the mini as a user that owns the git clone and LaunchAgent (usually your macOS account).
+- **Clone path** must match **`ProgramArguments`** in `~/Library/LaunchAgents/com.jonchui.mac-messages-mcp.plist` (often iCloud Drive path from the plist template).
+- **Tailscale** on laptop + mini (or LAN) so you can use `100.x.x.x` or MagicDNS.
+
+This Cursor/agent environment **does not** have your SSH keys or Tailscale DNS; **you** run the commands below from a trusted machine.
+
+## One-shot deploy (from laptop)
+
+Replace `USER`, `TAILSCALE_IP`, and the repo path with yours. The path must be the **actual clone** on the mini (match the plist `ProgramArguments` script path).
+
+```bash
+# From your laptop (replace user, IP, and quoted repo path on the mini):
+ssh -o BatchMode=yes USER@TAILSCALE_IP \
+  'bash "/Users/you/Library/Mobile Documents/com~apple~CloudDocs/code/mac_messages_mcp/scripts/deploy_mac_mini.sh" main'
+```
+
+Use branch `feat/tailscale-single-process-sse` until the single-process stack is merged to `main`.
+
+Or SSH interactively, `cd` to the repo, and run `./scripts/deploy_mac_mini.sh main`.
+
+## Deploy on the mini (logged in locally)
+
+```bash
+cd /path/to/mac_messages_mcp
+./scripts/deploy_mac_mini.sh main
+```
+
+Optional:
+
+```bash
+export DEPLOY_OPERATOR="jc"
+export MAC_MINI_SMOKE_TOKEN="your-bearer"   # if auth is enabled
+```
+
+## After deploy
+
+- **Cursor / `mcp.json`:** `http://<tailscale-ip>:8000/sse` plus `Authorization: Bearer …` if you use a token.
+- **Smoke:** `./scripts/status.sh` on the mini, or `curl http://127.0.0.1:8000/healthz`.
+
+## Deploy history
+
+Machine-readable log (append-only): [`deploy/history.jsonl`](../deploy/history.jsonl) (updated by `deploy_mac_mini.sh`).

--- a/mac_messages_mcp/http_server.py
+++ b/mac_messages_mcp/http_server.py
@@ -1,0 +1,129 @@
+"""
+Single-process HTTP + SSE entry for remote MCP (Tailscale / LAN).
+
+Mirrors ``FastMCP.run_sse_async`` (mcp SDK) Starlette routes, adds:
+  - ``GET /healthz`` / ``GET /status``
+  - optional Bearer / ``X-API-Key`` when ``MAC_MESSAGES_MCP_BEARER_TOKEN`` is set
+
+See GitHub issue #3 (single supervised process vs gateway + mcp-proxy).
+"""
+
+from __future__ import annotations
+
+import hmac
+import json
+import os
+from pathlib import Path
+
+import anyio
+import uvicorn
+from starlette.applications import Starlette
+from starlette.middleware.base import BaseHTTPMiddleware
+from starlette.requests import Request
+from starlette.responses import JSONResponse, PlainTextResponse, Response
+from starlette.routing import Mount, Route
+
+from mcp.server.fastmcp import FastMCP
+from mcp.server.sse import SseServerTransport
+
+
+def _expected_bearer() -> str | None:
+    tok = (
+        os.environ.get("MAC_MESSAGES_MCP_BEARER_TOKEN")
+        or os.environ.get("MCP_HTTP_BEARER_TOKEN")
+        or os.environ.get("MCP_PROXY_API_KEY")
+    )
+    return tok.strip() if tok else None
+
+
+def _load_deploy_info() -> dict:
+    raw = os.environ.get("MAC_MESSAGES_DEPLOY_INFO", ".runtime/deployed.json")
+    p = Path(raw)
+    if not p.is_absolute():
+        p = Path(os.getcwd()) / p
+    if not p.exists():
+        return {"status": "unknown", "message": "deploy metadata not found"}
+    try:
+        return json.loads(p.read_text())
+    except Exception as exc:
+        return {"status": "error", "message": str(exc)}
+
+
+class OptionalBearerMiddleware(BaseHTTPMiddleware):
+    """If ``MAC_MESSAGES_MCP_BEARER_TOKEN`` (or aliases) is set, require auth on MCP paths."""
+
+    _public_paths = frozenset({"/healthz", "/status"})
+
+    async def dispatch(self, request: Request, call_next):
+        path = request.url.path
+        if path in self._public_paths:
+            return await call_next(request)
+
+        expected = _expected_bearer()
+        if not expected:
+            return await call_next(request)
+
+        auth = request.headers.get("authorization", "")
+        api_key = request.headers.get("x-api-key", "")
+        token = ""
+        if auth.lower().startswith("bearer "):
+            token = auth[7:].strip()
+        elif api_key:
+            token = api_key.strip()
+
+        if len(token) != len(expected) or not hmac.compare_digest(
+            token.encode("utf-8"), expected.encode("utf-8")
+        ):
+            return Response(
+                status_code=401,
+                headers={"WWW-Authenticate": 'Bearer realm="mac-messages-mcp"'},
+            )
+        return await call_next(request)
+
+
+def build_starlette_app(fast_mcp: FastMCP) -> Starlette:
+    sse = SseServerTransport("/messages/")
+
+    async def handle_sse(request: Request):
+        async with sse.connect_sse(
+            request.scope, request.receive, request._send
+        ) as streams:
+            await fast_mcp._mcp_server.run(
+                streams[0],
+                streams[1],
+                fast_mcp._mcp_server.create_initialization_options(),
+            )
+
+    async def healthz(_: Request):
+        return PlainTextResponse("ok")
+
+    async def status(_: Request):
+        return JSONResponse(_load_deploy_info())
+
+    routes = [
+        Route("/healthz", endpoint=healthz, methods=["GET"]),
+        Route("/status", endpoint=status, methods=["GET"]),
+        Route("/sse", endpoint=handle_sse, methods=["GET"]),
+        Mount("/messages/", app=sse.handle_post_message),
+    ]
+
+    app = Starlette(debug=fast_mcp.settings.debug, routes=routes)
+    app.add_middleware(OptionalBearerMiddleware)
+    return app
+
+
+def serve_sse_http(fast_mcp: FastMCP) -> None:
+    """Run extended SSE app under Uvicorn (single process)."""
+
+    async def _serve() -> None:
+        starlette_app = build_starlette_app(fast_mcp)
+        config = uvicorn.Config(
+            starlette_app,
+            host=fast_mcp.settings.host,
+            port=fast_mcp.settings.port,
+            log_level=fast_mcp.settings.log_level.lower(),
+        )
+        server = uvicorn.Server(config)
+        await server.serve()
+
+    anyio.run(_serve)

--- a/mac_messages_mcp/server.py
+++ b/mac_messages_mcp/server.py
@@ -311,13 +311,20 @@ def run_server():
     """Run the MCP server with proper error handling.
     Set MCP_TRANSPORT=sse to serve over HTTP (default: stdio).
     When using SSE, set FASTMCP_HOST (default 0.0.0.0) and FASTMCP_PORT (default 8000).
+    Remote SSE uses a single Uvicorn process (see ``http_server``); use
+    ``scripts/run_http_service.sh`` + LaunchAgent instead of mcp-proxy + gateway.
     """
     transport = os.environ.get("MCP_TRANSPORT", "stdio").lower()
     if transport not in ("stdio", "sse"):
         transport = "stdio"
     try:
         logger.info("Starting Mac Messages MCP server (transport=%s)...", transport)
-        mcp.run(transport=transport)
+        if transport == "stdio":
+            mcp.run(transport="stdio")
+        else:
+            from mac_messages_mcp.http_server import serve_sse_http
+
+            serve_sse_http(mcp)
     except Exception as e:
         logger.error(f"Failed to start server: {str(e)}")
         sys.exit(1)

--- a/scripts/deploy_mac_mini.sh
+++ b/scripts/deploy_mac_mini.sh
@@ -1,0 +1,60 @@
+#!/usr/bin/env bash
+set -euo pipefail
+#
+# Run on the Mac mini (after SSH or at the console) from any cwd — resolves repo via script path.
+# Usage: ./scripts/deploy_mac_mini.sh [branch]   (default: main)
+#
+# Appends one JSON line to deploy/history.jsonl for audit trail.
+
+BRANCH="${1:-main}"
+SCRIPT_DIR="$(cd -- "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_DIR="$(cd -- "$SCRIPT_DIR/.." && pwd)"
+cd "$REPO_DIR"
+
+export PATH="${HOME}/.local/bin:${PATH}"
+
+if ! command -v git >/dev/null 2>&1; then
+  echo "❌ git not found" >&2
+  exit 1
+fi
+
+echo "== deploy_mac_mini: repo=$REPO_DIR branch=$BRANCH =="
+git fetch origin
+git checkout "$BRANCH"
+git pull --ff-only origin "$BRANCH"
+
+SHORT_SHA="$(git rev-parse --short HEAD)"
+
+if [ -x "$REPO_DIR/scripts/sync_launchagent.sh" ]; then
+  echo "== sync LaunchAgent plist from template =="
+  "$REPO_DIR/scripts/sync_launchagent.sh"
+fi
+
+echo "== restart LaunchAgent job =="
+"$REPO_DIR/scripts/restart.sh"
+
+mkdir -p "$REPO_DIR/deploy"
+LOG="$REPO_DIR/deploy/history.jsonl"
+TS="$(date -u +"%Y-%m-%dT%H:%M:%SZ")"
+HOST="$(hostname -s || hostname || echo unknown)"
+OPERATOR="${DEPLOY_OPERATOR:-$(whoami)}"
+printf '%s\n' "{\"ts\":\"${TS}\",\"host\":\"${HOST}\",\"branch\":\"${BRANCH}\",\"commit\":\"${SHORT_SHA}\",\"operator\":\"${OPERATOR}\",\"path\":\"${REPO_DIR}\"}" >>"$LOG"
+echo "== appended deploy record to $LOG =="
+tail -n 3 "$LOG"
+
+PORT="${FASTMCP_PORT:-8000}"
+TOKEN="${MAC_MINI_SMOKE_TOKEN:-${MAC_MESSAGES_MCP_BEARER_TOKEN:-${MCP_PROXY_API_KEY:-}}}"
+echo "== smoke: GET /healthz =="
+set +e
+if [[ -n "$TOKEN" ]]; then
+  curl -sS -f --max-time 5 -H "Authorization: Bearer $TOKEN" "http://127.0.0.1:${PORT}/healthz" && echo
+else
+  curl -sS -f --max-time 5 "http://127.0.0.1:${PORT}/healthz" && echo
+fi
+RC=$?
+set -e
+if [ "$RC" != 0 ]; then
+  echo "⚠️  /healthz failed (RC=$RC). Check ~/Library/Logs/mac-messages-mcp.err.log and plist ProgramArguments path."
+  exit "$RC"
+fi
+echo "✅ deploy_mac_mini complete"

--- a/scripts/install_macmessages_app.sh
+++ b/scripts/install_macmessages_app.sh
@@ -38,7 +38,8 @@ PLIST
 cat > "$LAUNCHER" <<'LAUNCHER'
 #!/usr/bin/env zsh
 set -euo pipefail
-exec "$HOME/bin/start_mcp_proxy.sh"
+REPO_DIR="${MAC_MESSAGES_MCP_REPO:-$HOME/Library/Mobile Documents/com~apple~CloudDocs/code/mac_messages_mcp}"
+exec /bin/bash "$REPO_DIR/scripts/run_http_service.sh"
 LAUNCHER
 
 chmod +x "$LAUNCHER"

--- a/scripts/mcp_gateway.py
+++ b/scripts/mcp_gateway.py
@@ -1,14 +1,16 @@
 #!/usr/bin/env python3
 """
-Small HTTP gateway in front of mcp-proxy:
-- exposes /status on the public port
-- proxies all other paths to mcp-proxy backend (supports SSE streaming)
+Legacy: HTTP gateway in front of Node ``mcp-proxy`` + FastMCP backend.
+
+**Preferred for Tailscale/LAN:** run ``scripts/run_http_service.sh`` (single
+Uvicorn + SSE; see mac_messages_mcp/http_server.py and GitHub issue #3).
+
+Keep this script for tunnel / ``mcp-proxy --tunnel`` workflows only.
 """
 
 from __future__ import annotations
 
 import argparse
-import asyncio
 import datetime as dt
 import hashlib
 import json
@@ -90,6 +92,29 @@ def extract_jsonrpc_method(body: bytes) -> str | None:
     return None
 
 
+def log_gateway_proxy_error(
+    request: Request,
+    req_headers: dict[str, str],
+    body: bytes,
+    exc: httpx.RequestError,
+) -> None:
+    sanitized_headers = {k: sanitize_header_value(k, v) for k, v in req_headers.items()}
+    client_ip = request.client.host if request.client else "unknown"
+    event = {
+        "event": "gateway_proxy_error",
+        "ts": dt.datetime.now(dt.timezone.utc).isoformat(),
+        "client_ip": client_ip,
+        "method": request.method,
+        "path": request.url.path,
+        "query": request.url.query,
+        "error_type": type(exc).__name__,
+        "error_message": str(exc),
+        "jsonrpc_method": extract_jsonrpc_method(body),
+        "headers": sanitized_headers,
+    }
+    print(json.dumps(event, ensure_ascii=True), flush=True)
+
+
 def log_gateway_request(
     request: Request,
     req_headers: dict[str, str],
@@ -127,6 +152,36 @@ def create_app(target_base: str, deploy_info_path: Path) -> Starlette:
     async def status_endpoint(_: Request) -> Response:
         return JSONResponse(load_deploy_info(deploy_info_path))
 
+    async def upstream_health(_: Request) -> Response:
+        """
+        TCP/HTTP probe of mcp-proxy (backend). The gateway process often outlives
+        the background `mcp-proxy` child; this endpoint makes that visible.
+        """
+        probe_url = f"{target_base}/"
+        try:
+            r = await client.get(probe_url, timeout=httpx.Timeout(3.0, connect=2.0))
+            body: dict = {
+                "upstream_probe": {"url": probe_url, "status_code": r.status_code},
+                "reachable": True,
+            }
+            status = 200
+            if r.status_code >= 500:
+                body["warning"] = "upstream returned 5xx; MCP routes may be broken"
+                status = 503
+            return JSONResponse(body, status_code=status)
+        except httpx.RequestError as exc:
+            return JSONResponse(
+                {
+                    "reachable": False,
+                    "error_type": type(exc).__name__,
+                    "message": str(exc),
+                    "hint": "mcp-proxy on the backend port may have crashed or been OOM-killed; "
+                    "LaunchAgent KeepAlive only supervises this gateway, not the proxy child. "
+                    "Run scripts/restart.sh on the Mac mini.",
+                },
+                status_code=503,
+            )
+
     async def proxy(request: Request) -> Response:
         target_url = f"{target_base}{request.url.path}"
         if request.url.query:
@@ -142,7 +197,21 @@ def create_app(target_base: str, deploy_info_path: Path) -> Starlette:
             headers=req_headers,
             content=body if body else None,
         )
-        upstream = await client.send(outbound, stream=True)
+        try:
+            upstream = await client.send(outbound, stream=True)
+        except httpx.RequestError as exc:
+            log_gateway_proxy_error(request, req_headers, body, exc)
+            return JSONResponse(
+                {
+                    "error": "bad_gateway",
+                    "detail": type(exc).__name__,
+                    "message": str(exc),
+                    "hint": "Backend mcp-proxy is unreachable from the gateway. "
+                    "It runs as a background child of start_mcp_proxy.sh and is not "
+                    "restarted automatically when it exits.",
+                },
+                status_code=502,
+            )
         log_gateway_request(request, req_headers, body, upstream.status_code)
 
         resp_headers = filter_headers(upstream.headers.items())
@@ -162,6 +231,7 @@ def create_app(target_base: str, deploy_info_path: Path) -> Starlette:
     app = Starlette(
         routes=[
             Route("/healthz", health, methods=["GET"]),
+            Route("/healthz/upstream", upstream_health, methods=["GET"]),
             Route("/status", status_endpoint, methods=["GET"]),
             Route(
                 "/{path:path}",

--- a/scripts/restart.sh
+++ b/scripts/restart.sh
@@ -6,10 +6,12 @@ PORT="${1:-8000}"
 SCRIPT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
 REPO_DIR="$(cd -- "$SCRIPT_DIR/.." && pwd)"
 API_KEY="${MCP_PROXY_API_KEY:-}"
+TOKEN="${MAC_MESSAGES_MCP_BEARER_TOKEN:-$API_KEY}"
 PLIST_PATH="$HOME/Library/LaunchAgents/$LABEL.plist"
 
 echo "Stopping stale MCP processes (if any)..."
 pkill -f "mcp-proxy" 2>/dev/null || true
+pkill -f "mcp_gateway.py" 2>/dev/null || true
 pkill -f "uv run python -m mac_messages_mcp.server" 2>/dev/null || true
 pkill -f "uv run --project.*mac-messages-mcp" 2>/dev/null || true
 
@@ -65,7 +67,7 @@ fi
 echo
 echo "LaunchAgent status:"
 launchctl print "gui/$(id -u)/$LABEL" | awk '
-  /state = / || /pid = / || /MCP_PROXY_PORT =>/ || /MCP_PROXY_SERVER_MODE =>/ || /MCP_PROXY_TUNNEL =>/
+  /state = / || /pid = / || /FASTMCP_PORT =>/ || /MCP_TRANSPORT =>/ || /MAC_MESSAGES_MCP_BEARER_TOKEN =>/
 '
 
 echo
@@ -74,12 +76,12 @@ lsof -nP -iTCP:"$PORT" -sTCP:LISTEN || true
 
 echo
 echo "Endpoint probes:"
-if [[ -n "$API_KEY" ]]; then
-  curl -sS -i --max-time 4 -H "X-API-Key: $API_KEY" "http://127.0.0.1:$PORT/mcp" | sed -n '1,10p' || true
+if [[ -n "$TOKEN" ]]; then
+  curl -sS -i --max-time 4 -H "Authorization: Bearer $TOKEN" "http://127.0.0.1:$PORT/healthz" | sed -n '1,12p' || true
   echo "---"
-  curl -sS -i --max-time 4 -H "X-API-Key: $API_KEY" "http://127.0.0.1:$PORT/sse" | sed -n '1,12p' || true
+  curl -sS -i --max-time 4 -H "Authorization: Bearer $TOKEN" "http://127.0.0.1:$PORT/sse" | sed -n '1,12p' || true
 else
-  curl -sS -i --max-time 4 "http://127.0.0.1:$PORT/mcp" | sed -n '1,10p' || true
+  curl -sS -i --max-time 4 "http://127.0.0.1:$PORT/healthz" | sed -n '1,12p' || true
   echo "---"
   curl -sS -i --max-time 4 "http://127.0.0.1:$PORT/sse" | sed -n '1,12p' || true
 fi

--- a/scripts/run_http_service.sh
+++ b/scripts/run_http_service.sh
@@ -1,0 +1,69 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Single-process MCP over HTTP/SSE for Tailscale or LAN (LaunchAgent-friendly).
+# See: mac_messages_mcp/http_server.py, https://github.com/jonchui/mac_messages_mcp/issues/3
+
+export PATH="$HOME/.local/bin:$PATH"
+export NVM_DIR="${NVM_DIR:-$HOME/.nvm}"
+if [ -s "$NVM_DIR/nvm.sh" ]; then
+  # shellcheck source=/dev/null
+  . "$NVM_DIR/nvm.sh"
+fi
+
+SCRIPT_DIR="$(cd -- "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_DIR="$(cd -- "$SCRIPT_DIR/.." && pwd)"
+cd "$REPO_DIR"
+
+export MCP_TRANSPORT=sse
+export FASTMCP_HOST="${FASTMCP_HOST:-0.0.0.0}"
+export FASTMCP_PORT="${FASTMCP_PORT:-8000}"
+
+# Prefer explicit env; else macOS Keychain (same service as legacy mcp-proxy).
+KEYCHAIN_SERVICE="${MCP_HTTP_BEARER_KEYCHAIN_SERVICE:-mac-messages-mcp/api-key}"
+KEYCHAIN_ACCOUNT="${MCP_HTTP_BEARER_KEYCHAIN_ACCOUNT:-$USER}"
+if [ -z "${MAC_MESSAGES_MCP_BEARER_TOKEN:-}" ] && command -v security >/dev/null 2>&1; then
+  MAC_MESSAGES_MCP_BEARER_TOKEN="$(
+    security find-generic-password -a "$KEYCHAIN_ACCOUNT" -s "$KEYCHAIN_SERVICE" -w 2>/dev/null || true
+  )"
+  export MAC_MESSAGES_MCP_BEARER_TOKEN
+fi
+
+mkdir -p "$REPO_DIR/.runtime"
+GIT_BIN="$(command -v git || true)"
+if [ -z "$GIT_BIN" ] && [ -x /usr/bin/git ]; then
+  GIT_BIN="/usr/bin/git"
+fi
+branch="$("$GIT_BIN" rev-parse --abbrev-ref HEAD 2>/dev/null || echo unknown)"
+commit="$("$GIT_BIN" rev-parse --short HEAD 2>/dev/null || echo unknown)"
+commit_subject="$("$GIT_BIN" log -1 --pretty=%s 2>/dev/null || echo unknown)"
+if [ -n "$("$GIT_BIN" status --porcelain 2>/dev/null || true)" ]; then
+  dirty="dirty"
+else
+  dirty="clean"
+fi
+DEPLOYED_AT="$(date -u +"%Y-%m-%dT%H:%M:%SZ")" \
+  BRANCH="$branch" \
+  COMMIT="$commit" \
+  COMMIT_SUBJECT="$commit_subject" \
+  STATE="$dirty" \
+  PUBLIC_PORT="$FASTMCP_PORT" \
+  python3 - <<'PY' >"$REPO_DIR/.runtime/deployed.json"
+import json
+import os
+
+payload = {
+    "deployed_at": os.environ.get("DEPLOYED_AT", "unknown"),
+    "branch": os.environ.get("BRANCH", "unknown"),
+    "commit": os.environ.get("COMMIT", "unknown"),
+    "commit_subject": os.environ.get("COMMIT_SUBJECT", "unknown"),
+    "state": os.environ.get("STATE", "unknown"),
+    "public_port": int(os.environ.get("PUBLIC_PORT", "0")),
+    "transport": "sse",
+    "process_model": "single_uvicorn",
+}
+print(json.dumps(payload))
+PY
+
+echo "mac-messages-mcp HTTP: host=$FASTMCP_HOST port=$FASTMCP_PORT auth=$([ -n "${MAC_MESSAGES_MCP_BEARER_TOKEN:-}" ] && echo bearer || echo none)"
+exec uv run --project "$REPO_DIR" python -m mac_messages_mcp.server

--- a/scripts/start_mcp_proxy.sh
+++ b/scripts/start_mcp_proxy.sh
@@ -1,6 +1,9 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
+# Legacy multi-process stack: Node mcp-proxy (background) + Python mcp_gateway.
+# For Tailscale-only access use scripts/run_http_service.sh (single process).
+#
 # Ensure user-level toolchains are available in launchd shells.
 export PATH="$HOME/.local/bin:$PATH"
 export NVM_DIR="$HOME/.nvm"

--- a/scripts/status.sh
+++ b/scripts/status.sh
@@ -9,7 +9,7 @@ SCRIPT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
 REPO_DIR="$(cd -- "$SCRIPT_DIR/.." && pwd)"
 
 PORT="${1:-8000}"
-API_KEY="${MCP_PROXY_API_KEY:-}"
+TOKEN="${MAC_MESSAGES_MCP_BEARER_TOKEN:-${MCP_PROXY_API_KEY:-}}"
 
 echo "== MCP Service Status =="
 echo "Label: $LABEL"
@@ -37,7 +37,7 @@ echo
 if launchctl print "gui/$(id -u)/$LABEL" >/tmp/mcp_status.$$ 2>/dev/null; then
   echo "-- launchctl --"
   awk '
-    /state = / || /pid = / || /MCP_PROXY_PORT =>/ || /MCP_PROXY_SERVER_MODE =>/ || /MCP_PROXY_TUNNEL =>/ || /MCP_PROXY_HOST =>/
+    /state = / || /pid = / || /FASTMCP_PORT =>/ || /MCP_TRANSPORT =>/
   ' /tmp/mcp_status.$$
 else
   echo "-- launchctl --"
@@ -55,15 +55,15 @@ fi
 echo
 
 echo "-- local endpoint probe --"
-if [[ -n "$API_KEY" ]]; then
-  curl -sS -i --max-time 4 -H "X-API-Key: $API_KEY" "http://127.0.0.1:$PORT/mcp" | sed -n '1,10p' || true
+if [[ -n "$TOKEN" ]]; then
+  curl -sS -i --max-time 4 -H "Authorization: Bearer $TOKEN" "http://127.0.0.1:$PORT/healthz" | sed -n '1,10p' || true
   echo "---"
-  curl -sS -i --max-time 4 -H "X-API-Key: $API_KEY" "http://127.0.0.1:$PORT/sse" | sed -n '1,12p' || true
+  curl -sS -i --max-time 4 -H "Authorization: Bearer $TOKEN" "http://127.0.0.1:$PORT/sse" | sed -n '1,12p' || true
 else
-  curl -sS -i --max-time 4 "http://127.0.0.1:$PORT/mcp" | sed -n '1,10p' || true
+  curl -sS -i --max-time 4 "http://127.0.0.1:$PORT/healthz" | sed -n '1,10p' || true
   echo "---"
   curl -sS -i --max-time 4 "http://127.0.0.1:$PORT/sse" | sed -n '1,12p' || true
-  echo "(Tip: set MCP_PROXY_API_KEY env var before running for authenticated probe.)"
+  echo "(Tip: set MAC_MESSAGES_MCP_BEARER_TOKEN or MCP_PROXY_API_KEY for authenticated /sse probe.)"
 fi
 echo
 


### PR DESCRIPTION
## Summary
Implements the plan in #3: **one Uvicorn/Starlette process** for remote MCP (SSE + `/messages/`) with **`/healthz`** and **`/status`**, optional **Bearer / X-API-Key** (env `MAC_MESSAGES_MCP_BEARER_TOKEN` / Keychain `mac-messages-mcp/api-key`). LaunchAgent template now runs **`scripts/run_http_service.sh`** instead of **gateway + background `mcp-proxy`**.

**Legacy:** `start_mcp_proxy.sh` + `mcp_gateway.py` kept for tunnel / WAN stacks; README calls out Tailscale path first.

## Operator notes
- Sync plist: `./scripts/sync_launchagent.sh` then `./scripts/restart.sh` (or let pre-commit sync when template changes).
- If your clone path ≠ plist `ProgramArguments`, edit the plist or set `MAC_MESSAGES_MCP_REPO` for the `.app` launcher from `install_macmessages_app.sh`.
- Cursor: still `http://<tailscale-ip>:8000/sse` + `Authorization: Bearer …` when token is set.

## Test plan
- [x] `pytest`
- [ ] Mac mini: pull branch, restart LaunchAgent, `curl http://127.0.0.1:8000/healthz` and authenticated `/sse`

Closes #3

Made with [Cursor](https://cursor.com)